### PR TITLE
refactor(sceneChanger): 씬 체인저 방식 변경

### DIFF
--- a/Assets/Scene/lab.unity
+++ b/Assets/Scene/lab.unity
@@ -2861,7 +2861,6 @@ GameObject:
   - component: {fileID: 783923612}
   - component: {fileID: 783923611}
   - component: {fileID: 783923610}
-  - component: {fileID: 783923609}
   - component: {fileID: 783923613}
   m_Layer: 8
   m_Name: MoveToBench
@@ -2870,20 +2869,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &783923609
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 783923607}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 781f9e5c6b6a20544b42edd08d033501, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  sceneChanger: {fileID: 783923613}
-  newPlayerPos: {x: 0, y: 0}
 --- !u!61 &783923610
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -3013,6 +2998,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   targetSceneName: bench
+  targetPosition: {x: -7, y: 2.5}
+  isTrigger: 0
 --- !u!1 &795042579
 GameObject:
   m_ObjectHideFlags: 0
@@ -4250,7 +4237,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1022896023}
   - component: {fileID: 1022896022}
-  - component: {fileID: 1022896025}
   - component: {fileID: 1022896024}
   m_Layer: 0
   m_Name: MoveSceneToVillage
@@ -4293,7 +4279,7 @@ BoxCollider2D:
   m_UsedByEffector: 0
   m_CompositeOperation: 0
   m_CompositeOrder: 0
-  m_Offset: {x: 9.45112, y: -0.5007405}
+  m_Offset: {x: 0, y: 0}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0, y: 0}
@@ -4303,7 +4289,7 @@ BoxCollider2D:
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
-  m_Size: {x: 1.253047, y: 4.9289875}
+  m_Size: {x: 3, y: 3}
   m_EdgeRadius: 0
 --- !u!4 &1022896023
 Transform:
@@ -4314,7 +4300,7 @@ Transform:
   m_GameObject: {fileID: 1022896021}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 2.69032, y: -1.82651, z: 0}
+  m_LocalPosition: {x: 10.5, y: -3, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -4333,20 +4319,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   targetSceneName: Village
---- !u!114 &1022896025
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1022896021}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 781f9e5c6b6a20544b42edd08d033501, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  sceneChanger: {fileID: 1022896024}
-  newPlayerPos: {x: -1.8, y: 2.5}
+  targetPosition: {x: -1.8, y: 2.5}
+  isTrigger: 1
 --- !u!1 &1022931145
 GameObject:
   m_ObjectHideFlags: 0
@@ -7685,7 +7659,6 @@ GameObject:
   - component: {fileID: 2038711225}
   - component: {fileID: 2038711224}
   - component: {fileID: 2038711223}
-  - component: {fileID: 2038711226}
   - component: {fileID: 2038711227}
   m_Layer: 8
   m_Name: MoveToMixture
@@ -7707,6 +7680,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   targetSceneName: Mixture
+  targetPosition: {x: 0, y: 0}
+  isTrigger: 0
 --- !u!212 &2038711224
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -7777,20 +7752,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &2038711226
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2038711222}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 781f9e5c6b6a20544b42edd08d033501, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  sceneChanger: {fileID: 2038711223}
-  newPlayerPos: {x: 0, y: 0}
 --- !u!58 &2038711227
 CircleCollider2D:
   m_ObjectHideFlags: 0
@@ -22010,6 +21971,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   targetSceneName: Main
+  targetPosition: {x: 0, y: 0}
+  isTrigger: 0
 --- !u!224 &8800547821471034788
 RectTransform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -180,16 +180,6 @@ public class Player : MonoBehaviour
                 return;
             }
 
-            if (detection.collider.CompareTag("bench"))
-            {
-                SceneChanger sceneChanger = detection.collider.GetComponent<SceneChanger>();
-                if (sceneChanger != null)
-                {
-                    sceneChanger.MoveToScene();
-                    return;
-                }
-            }
-
             IInteract interact = detection.collider.GetComponent<IInteract>();
             if (interact != null) interact.Interact(this);
         }
@@ -216,16 +206,6 @@ public class Player : MonoBehaviour
             // 우선순위 별로 상호작용 오브젝트 상호작용 (작물 > 농지 > 바닥에 있는 아이템)
 
             // 올바른 도구를 장착했는지 확인 >> 도구가 무슨 종류인지 확인 필요
-            // 작업대
-            SceneChanger sceneChanger = hitCollider.GetComponent<SceneChanger>();
-            if (sceneChanger != null)
-            {
-                if (hitCollider.CompareTag("bench"))
-                {
-                    sceneChanger.MoveToScene();
-                    return;
-                }
-            }
 
             IInteract interact = hitCollider.GetComponent<IInteract>();
             interact.Interact(this);

--- a/Assets/Scripts/SceneChanger.cs
+++ b/Assets/Scripts/SceneChanger.cs
@@ -1,27 +1,25 @@
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
-public class SceneChanger : MonoBehaviour
+public class SceneChanger : MonoBehaviour, IInteract
 {
     [Header("이동한 씬")]
     [SerializeField] private string targetSceneName;
-
-    public void MoveToScene()
+    [Header("이동할 위치")]
+    [SerializeField] public Vector2 targetPosition;
+    [Header("이동 방식")]
+    [SerializeField] public bool isTrigger;
+    
+    public void MoveToScene(Player player)
     {
-        if (string.IsNullOrEmpty(targetSceneName))
-        {
-            Debug.Log("씬 이름이 설정 안됨", this);
-            return;
-        }
-
-        string currentScene = UnityEngine.SceneManagement.SceneManager.GetActiveScene().name;
+        string currentScene = SceneManager.GetActiveScene().name;
         if (currentScene == "Main")
         {
-            if (this.name == "Play")
+            if (name == "Play")
             {
                 SaveManager.Instance.ResetGame();
             }
-            else if (this.name == "Load")
+            else if (name == "Load")
             {
                 SaveManager.Instance.LoadGame();
             }
@@ -31,5 +29,40 @@ public class SceneChanger : MonoBehaviour
 
         Resources.UnloadUnusedAssets();
         SceneManager.LoadScene(targetSceneName);
+        
+        player.transform.position = targetPosition;
+    }
+
+    public void Interact(Player player)
+    {
+        if(CanInteract(player)) MoveToScene(player);
+    }
+
+    public bool CanInteract(Player player)
+    {
+        if (string.IsNullOrEmpty(targetSceneName))
+        {
+            Debug.Log("씬 이름이 설정 안됨", this);
+            return false;
+        }
+
+        return true;
+    }
+    
+    private void OnTriggerEnter2D(Collider2D other)
+    {
+        if (!isTrigger)
+        {
+            Debug.Log("트리거 이동 방식이 아님");
+            return;
+        }
+
+        if (!other.CompareTag("Player"))
+        {
+            Debug.Log("충돌한 객체가 플레이어가 아님");
+            return;
+        }
+        Player player = other.GetComponent<Player>();
+        Interact(player);
     }
 }

--- a/Assets/Scripts/SceneChangerOnTrigger.cs
+++ b/Assets/Scripts/SceneChangerOnTrigger.cs
@@ -1,20 +1,23 @@
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 public class SceneChangerOnTrigger : MonoBehaviour
 {
     [SerializeField] private SceneChanger sceneChanger;
-
-    public Vector2 newPlayerPos;
-
     private void OnTriggerEnter2D(Collider2D other)
     {
-        if (!other.CompareTag("Player")) return;
-
-        if (sceneChanger != null)
+        if (sceneChanger == null)
         {
-            sceneChanger.MoveToScene();
-            other.transform.position = newPlayerPos; // ÇÃ·¹ÀÌ¾î À§Ä¡ Á¶Á¤
+            Debug.Log("ì”¬ ì²´ì¸ì € ì—†ìŒ");
+            return;
         }
-        else Debug.LogWarning("SceneChanger ¿¬°á¾ÈµÊ", this);
+
+        if (!other.CompareTag("Player"))
+        {
+            Debug.Log("ì¶©ëŒí•œ ê°ì²´ê°€ í”Œë ˆì´ì–´ê°€ ì•„ë‹˜");
+            return;
+        }
+        Player player = other.GetComponent<Player>();
+        sceneChanger.MoveToScene(player);
     }
 }

--- a/Assets/Scripts/Tutorial/TutorialConditionType.cs
+++ b/Assets/Scripts/Tutorial/TutorialConditionType.cs
@@ -6,5 +6,5 @@ public enum TutorialConditionType
     CheckForTilledSoil,   // 흙이 설치되었는지 확인
     CheckForWateredSoil,  // 흙에 물을 주었는지 확인
     CheckForSeededSoil,   // 흙에 씨앗을 심었는지 확인
-    CheckBenchInteraction // 작업대 씬으로 이동했는지 확인
+    CheckCurrentSceneVillage // 작업대 씬으로 이동했는지 확인
 }

--- a/Assets/Scripts/Tutorial/TutorialManager.cs
+++ b/Assets/Scripts/Tutorial/TutorialManager.cs
@@ -131,8 +131,8 @@ public class TutorialManager : MonoBehaviour
                 return CheckForWateredSoil();
             case TutorialConditionType.CheckForSeededSoil:
                 return CheckForSeededSoil();
-            case TutorialConditionType.CheckBenchInteraction:
-                return CheckBenchInteraction();
+            case TutorialConditionType.CheckCurrentSceneVillage:
+                return CheckCurrentSceneVillage();
             case TutorialConditionType.None:
                 return true; // 'None' 조건은 항상 참
             default:
@@ -213,11 +213,11 @@ public class TutorialManager : MonoBehaviour
         return false;
     }
 
-    private bool CheckBenchInteraction()
+    private bool CheckCurrentSceneVillage()
     {
-        if (UnityEngine.SceneManagement.SceneManager.GetActiveScene().name == "bench")
+        if (UnityEngine.SceneManagement.SceneManager.GetActiveScene().name == "Village")
         {
-            Debug.Log("작업대 씬 이동 확인!");
+            Debug.Log("마을 씬 이동 확인!");
             return true;
         }
         return false;


### PR DESCRIPTION

# 씬 체인저 방식 변경

씬 체인저 방식을 변경했습니다. 기존에는 `sceneChanger`와 `sceneChangerOnTrigger`로 나눠져 있었습니다. 이젠 `sceneChanger`에서 `isTrigger`를 true로 설정하면 `sceneChangerOnTrigger`와 동일하게 작동합니다.

# 씬 체인저 이동 위치 확인

기존 트리거 방식은 플레이어 생성 위치가 계속 같은 자리에 나와서 문제가 생겼습니다. 이를 해결하기 위해 `sceneChanger`에 targetPosition 변수를 두어서 나오는 위치를 지정할 수 있도록 했습니다.